### PR TITLE
Version pinning metric

### DIFF
--- a/src/github_repository.ts
+++ b/src/github_repository.ts
@@ -143,8 +143,6 @@ export class GithubRepository extends Repository {
 			}
 		}
 
-		console.log(response?.data.length)
-
 		// uses octokit REST API to fetch issues list
 		/* const iterator:IteratorResponseType = this.octokit.paginate.iterator(this.octokit.rest.issues.listForRepo, {
 		  owner: this.owner,
@@ -352,13 +350,13 @@ export class GithubRepository extends Repository {
 		});
 	}
 
-	async get_package_json():Promise<string | null> {
+	async get_package_json():Promise<any | null> {
 		type ContentResponseType = GetResponseTypeFromEndpointMethod<
 		typeof this.octokit.rest.repos.getContent>;
 		type ContentResponseDataType = GetResponseDataTypeFromEndpointMethod<
 		typeof this.octokit.rest.repos.getContent>; 
 		var cdata:ContentResponseDataType;
-		var rv:string|null = null;
+		var rv:any|null = null;
 
 		// uses octokit REST API to fetch license data
 		try {

--- a/src/github_repository.ts
+++ b/src/github_repository.ts
@@ -350,7 +350,42 @@ export class GithubRepository extends Repository {
 		return new Promise((resolve) => {
 			resolve(rv);
 		});
-	}                                                                                                                          
+	}
+
+	async get_package_json():Promise<string | null> {
+		type ContentResponseType = GetResponseTypeFromEndpointMethod<
+		typeof this.octokit.rest.repos.getContent>;
+		type ContentResponseDataType = GetResponseDataTypeFromEndpointMethod<
+		typeof this.octokit.rest.repos.getContent>; 
+		var cdata:ContentResponseDataType;
+		var rv:string|null = null;
+
+		// uses octokit REST API to fetch license data
+		try {
+			var content:ContentResponseType = await this.octokit.rest.repos.getContent({
+			  owner: this.owner,
+			  repo: this.repo,
+			  path: 'package.json',
+			});
+			cdata = content.data;
+			logger.log('info', "Fetched package file from " + this.owner + "/" + this.repo);
+		} catch (error) {
+			logger.log('debug', "Could not fetch package file from " + this.owner + "/" + this.repo);
+			return new Promise((resolve) => {
+				resolve(rv);
+			});	
+		}
+
+		// this does not work for some reason - debug
+		// this is a workaround since we cannot seem to access object properties of cdata above
+		var jdata = JSON.parse(JSON.stringify(cdata));
+		var decoded:string = Buffer.from(jdata.content, 'base64').toString('ascii')
+		var pkg = JSON.parse(decoded)
+
+		return new Promise((resolve) => {
+			resolve(pkg);
+		});	
+	}
  }                                                                                            
  
  

--- a/src/metric.ts
+++ b/src/metric.ts
@@ -425,7 +425,6 @@ export class VersionMetric extends Metric {
     async get_metric(repo: Repository):Promise<GroupMetric> {
         let score:number =  0; // subscore for readme
         let packages:any = await repo.get_package_json(); //get the readme
-		
 
         //read me calcs
         if(packages == null){
@@ -433,7 +432,6 @@ export class VersionMetric extends Metric {
             score = 1;
         }
         else{
-			//console.log(packages)
             score = await versionCalc(packages); //calc the readme score
         }
 
@@ -461,9 +459,6 @@ async function versionCalc(packages: any): Promise<number> {
 		totalNumberOfDependencies += Object.keys(packages.optionalDependencies).length;
 	}
 
-	//console.log(packages?.dependencies)
-	
-
 	numberPinnedToMajorMinor += await countPinnedToMajorMinor(packages?.dependencies);
 	numberPinnedToMajorMinor += await countPinnedToMajorMinor(packages?.devDependencies);
 	numberPinnedToMajorMinor += await countPinnedToMajorMinor(packages?.peerDependencies);
@@ -480,14 +475,10 @@ async function countPinnedToMajorMinor(dependencies: any): Promise<number> {
 	const re = /^\d+\.\d+\.(x|X)$/
 
 	for (const dependency in dependencies) {
-		//console.log(dependencies[dependency])
-		console.log(re.test('0.3.x'))
 		if (re.test(dependencies[dependency])) {
 			count++;
 		}
 	}
-
-	//console.log(count)
 
 	return count;
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -46,5 +46,5 @@ export abstract class Repository {
     abstract get_readme():Promise<string | null>;
     abstract get_contributors_stats():Promise<Contributions>;
 
-	abstract get_package_json():Promise<string | null>;
+	abstract get_package_json():Promise<any | null>;
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -45,4 +45,6 @@ export abstract class Repository {
 	*/
     abstract get_readme():Promise<string | null>;
     abstract get_contributors_stats():Promise<Contributions>;
+
+	abstract get_package_json():Promise<string | null>;
 }

--- a/tests/scores.test.ts
+++ b/tests/scores.test.ts
@@ -29,7 +29,7 @@ global.logger = logger;
 describe('Get weighted sum test', () => {
 	test('all 1', () => {
 		var no_net:ScoresWithoutNet = new ScoresWithoutNet('https://github.com/cloudinary/cloudinary_npm',
-		1, 1, 1, 1, 1);
+		1, 1, 1, 1, 1, 1);
 		const nscore = get_weighted_sum(no_net);
 		expect(nscore.net_score).toEqual(1);
 	});
@@ -38,7 +38,7 @@ describe('Get weighted sum test', () => {
 describe('Get weighted sum test', () => {
 	test('license 0', () => {
 		var no_net:ScoresWithoutNet = new ScoresWithoutNet('https://github.com/cloudinary/cloudinary_npm',
-		0, 1, 1, 1, 1);
+		0, 1, 1, 1, 1, 1);
 		const nscore = get_weighted_sum(no_net);
 		expect(nscore.net_score).toEqual(0);
 	});
@@ -47,7 +47,7 @@ describe('Get weighted sum test', () => {
 describe('Get weighted sum test', () => {
 	test('all 0', () => {
 		var no_net:ScoresWithoutNet = new ScoresWithoutNet('https://github.com/cloudinary/cloudinary_npm',
-		0, 0, 0, 0, 0);
+		0, 0, 0, 0, 0, 0);
 		const nscore = get_weighted_sum(no_net);
 		expect(nscore.net_score).toEqual(0);
 	});
@@ -56,7 +56,7 @@ describe('Get weighted sum test', () => {
 describe('Get weighted sum test', () => {
 	test('null implemented score', () => {
 		var no_net:ScoresWithoutNet = new ScoresWithoutNet('https://github.com/cloudinary/cloudinary_npm',
-		null, 0, 0, 0, 0);
+		null, 0, 0, 0, 0, 0);
 		const nscore = get_weighted_sum(no_net);
 		expect(nscore.license_score).toEqual(0);
 	});
@@ -66,7 +66,7 @@ describe('Get weighted sum test', () => {
 describe('Get weighted sum test', () => {
 	test('null unimplemented score', () => {
 		var no_net:ScoresWithoutNet = new ScoresWithoutNet('https://github.com/cloudinary/cloudinary_npm',
-		0, 0, 0, 0, null);
+		0, 0, 0, 0, null, 0);
 		const nscore = get_weighted_sum(no_net);
 		expect(nscore.responsive_maintainer_score).toEqual(-1);
 	});


### PR DESCRIPTION
'The fraction of dependencies that are pinned to at least a specific major+minor version, e.g., version 2.3.X of a package. (If there are zero dependencies, they should receive a 1.0 rating. If there are two dependencies, one pinned to this degree, then they should receive a ½ = 0.5 rating)'

Might want to change up the weighting on this at a later point since it's uncommon for dependencies to be pinned this way, so the score for this particular metric usually ends up low.